### PR TITLE
regex/mlx5: Add enqueue function

### DIFF
--- a/drivers/regex/mlx5/Makefile
+++ b/drivers/regex/mlx5/Makefile
@@ -10,6 +10,7 @@ LIB = librte_pmd_mlx5_regex.a
 SRCS-$(CONFIG_RTE_LIBRTE_MLX5_REGEX_PMD) += mlx5.c
 SRCS-$(CONFIG_RTE_LIBRTE_MLX5_REGEX_PMD) += mlx5_regex.c
 SRCS-$(CONFIG_RTE_LIBRTE_MLX5_REGEX_PMD) += mlx5_regex_mr.c
+SRCS-$(CONFIG_RTE_LIBRTE_MLX5_REGEX_PMD) += mlx5_regex_queue.c
 
 # Basic CFLAGS.
 CFLAGS += -O3

--- a/drivers/regex/mlx5/mlx5.h
+++ b/drivers/regex/mlx5/mlx5.h
@@ -4,6 +4,7 @@
 #include <rte_regexdev_driver.h>
 #include <rte_rwlock.h>
 
+#include "mlx5_regex_queue.h"
 #include "mlx5_regex_mr.h"
 
 struct mlx5_database_ctx {
@@ -31,6 +32,7 @@ struct mlx5_regex_priv {
 		struct mlx5_mr_list mr_list; /* Registered MR list. */
 		struct mlx5_mr_list mr_free_list; /* Freed MR list. */
 	} mr;
+	struct mlx5_regex_queue *(*queues)[]; /* Device queues */
 };
 
 #endif

--- a/drivers/regex/mlx5/mlx5_regex_queue.c
+++ b/drivers/regex/mlx5/mlx5_regex_queue.c
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2020 Mellanox Technologies, Ltd
+ */
+
+#include "mlx5.h"
+#include "mlx5_regex_queue.h"
+
+/**
+ * Send a single request
+ *
+ * @param dev
+ *   Pointer to REGEX device.
+ * @param q
+ *   The queue to send the request.
+ * @param ops
+ *   Pointer to the request.
+ *
+ * @return
+ *   0: success else error code.
+ */
+static int
+tx_burst_msegs_op(struct rte_regex_dev *dev, struct mlx5_regex_queue *q,
+		  struct rte_regex_ops *ops)
+{
+	struct mlx5_regex_priv *priv =
+		container_of(dev, struct mlx5_regex_priv, regex_dev);
+	struct mlx5_wqe_metadata_seg *restrict mseg;
+	struct mlx5_regex_wqe_ctrl_seg regex_cseg;
+	struct mlx5_wqe_data_seg *restrict dseg;
+	struct mlx5_wqe_ctrl_seg *restrict cseg;
+	struct mlx5_wqe_data_seg tmp_dseg;
+	int wqe_idx = q->q_pi % q->q_size;
+	struct mlx5_regex_buffers *regex_buf;
+	size_t wqe_offset;
+	uint64_t *db_addr;
+	uint32_t lkey;
+	int ds, i;
+
+	if (q->q_pi - q->q_ci >= q->q_size)
+		return EBUSY;
+
+	ds = ops->num_of_bufs;
+	/* REGEX dev currently support single segment req buf. */
+	assert(ds > 1 && ds < 2);
+	/*
+	 * WQE:
+	 * - 1 Control Segment
+	 * - 1 Metadata Segment
+	 * - nseg = 1 Data Segments for request
+	 * - 1 Data Segment for response
+	 */
+	ds += 3;
+	wqe_offset = wqe_idx * MLX5_SEND_WQE_BB ;
+	regex_buf = q->regex_bufs[wqe_idx];
+	cseg = (struct mlx5_wqe_ctrl_seg *)((uint8_t*)q->wqes + wqe_offset);
+	/* TODO: ask Yuval about the last param ctrl_field */
+	set_ctrl_seg((void *)&regex_cseg, 0, ops, /* ctrl_field */ 0);
+	mlx5dv_set_ctrl_seg(cseg, q->q_pi, MLX5_OPCODE_MMO,
+			    MLX5_OPC_MOD_MMO_REGEX, q->sqn,
+			    MLX5_WQE_CTRL_CQ_UPDATE, ds, 0,
+			    regex_cseg.le_subset_id_0_subset_id_1);
+	/* Set wqe metadata segment */
+	mseg = (struct mlx5_wqe_metadata_seg *)((uint8_t*)cseg + sizeof(*cseg));
+	lkey = mlx5_regex_mr_addr2mr_bh(dev, &q->mr_ctrl,
+					regex_buf->m_iov.buf_iova);
+	mlx5dv_set_data_seg(&tmp_dseg, regex_buf->m_iov.buf_size,
+			    lkey, regex_buf->m_iov.buf_iova);
+	mlx5dv_set_metadata_seg(mseg, regex_cseg.ctrl_subset_id_2_subset_id_3,
+				lkey, tmp_dseg.addr);
+	/* Data segment for nsegs buffer */
+	dseg = (struct mlx5_wqe_data_seg *)((uint8_t*)mseg + sizeof(*mseg));
+	for (i = 0; i < ds; ++i) {
+		lkey = mlx5_regex_mr_addr2mr_bh(dev, &q->mr_ctrl,
+						(*ops->bufs)[i]->buf_iova);
+		mlx5dv_set_data_seg(dseg, (*ops->bufs)[i]->buf_size,
+				    lkey, (*ops->bufs)[i]->buf_iova);
+		++dseg;
+	}
+	/* Data segment for response buffer */
+	lkey = mlx5_regex_mr_addr2mr_bh(dev, &q->mr_ctrl,
+					regex_buf->resp_iov.buf_iova);
+	mlx5dv_set_data_seg(dseg, regex_buf->resp_iov.buf_size,
+			    lkey, regex_buf->resp_iov.buf_iova);
+
+	/* Ring doorbell */
+	db_addr = (uint64_t *)((uint8_t *)priv->uar->base_addr + 0x800);
+	asm volatile("" ::: "memory");
+	q->q_db[MLX5_SND_DBR] = htobe32(q->q_pi & 0xffff);
+	asm volatile("" ::: "memory");
+	*db_addr = *(uint64_t *)cseg;
+	asm volatile("" ::: "memory");
+
+	++q->q_pi;
+	return 0;
+}
+
+/**
+ * Enqueue a burst of scan requests to a queue of REGEX device
+ *
+ * @param dev
+ *   Pointer to REGEX device.
+ * @param q_id
+ *   Index of the queue.
+ * @param ops
+ *   Pointer to an array of requests.
+ * @param nb_ops
+ *   Number of requests in the ops array.
+ *
+ * @return
+ *   Number of requests processed.
+ */
+int mlx5_regex_enqueue(struct rte_regex_dev *dev, uint16_t q_id,
+		       struct rte_regex_ops **ops, uint16_t nb_ops)
+{
+	struct mlx5_regex_priv *priv =
+		container_of(dev, struct mlx5_regex_priv, regex_dev);
+	struct mlx5_regex_queue *q = (*priv->queues)[q_id];
+	int processed = 0;
+	int err;
+	int i;
+
+	if (unlikely(!nb_ops) || q->busy)
+		return 0;
+
+	for (i = 0; i < nb_ops; i++) {
+		err = tx_burst_msegs_op(dev, q, ops[i]);
+		if (err)
+			break;
+		++processed;
+	}
+	return processed;
+}

--- a/drivers/regex/mlx5/mlx5_regex_queue.h
+++ b/drivers/regex/mlx5/mlx5_regex_queue.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2020 Mellanox Technologies, Ltd
+ */
+
+#ifndef MLX5_REGEX_QUEUE_H_
+#define MLX5_REGEX_QUEUE_H_
+
+#include <mlx5_prm.h>
+#include "mlx5_regex_mr.h"
+
+struct mlx5_regex_wqe_ctrl_seg {
+	__be32 le_subset_id_0_subset_id_1;
+	__be32 ctrl_subset_id_2_subset_id_3;
+};
+
+struct mlx5_regex_buffers {
+	struct rte_regex_iov m_iov; /* Buffer for metadata */
+	struct rte_regex_iov resp_iov; /* Buffer to receive response from dev */
+} __rte_cache_aligned;
+
+/* Queue structure to send requests and receive responses */
+struct mlx5_regex_queue {
+	uint16_t q_id; /* Index of this queue */
+	struct mlx5_mr_ctrl mr_ctrl; /* MR control descriptor */
+	/* CQ related fields. */
+	void *cqes; /* Completion queue. */
+	volatile uint32_t *cq_db; /* Completion queue doorbell. */
+	uint16_t cq_ci; /* Consumer index for completion queue. */
+	/* WQ related fields. */
+	uint32_t sqn; /* sq num */
+	void *wqes; /* Work queue. */
+	uint16_t q_pi; /* Producer index for work queue. */
+	uint16_t q_ci; /* Producer index for work queue. */
+	uint16_t q_size; /* Size of the work queue. */
+	volatile uint32_t *q_db; /* Work queue doorbell. */
+	bool busy; /* State of the queue is being used or not. */
+	/* Buffers for reqs, metadata and receive responses from dev */
+	struct mlx5_regex_buffers *regex_bufs[];
+} __rte_cache_aligned;
+
+LIST_HEAD(mlx5_queue_list, mlx5_queue);
+
+static __rte_always_inline void
+set_ctrl_seg(void *seg, uint8_t le, struct rte_regex_ops *ops, uint8_t ctrl)
+{
+	DEVX_SET(regexp_mmo_control, seg, le, le);
+	DEVX_SET(regexp_mmo_control, seg, ctrl, ctrl);
+	DEVX_SET(regexp_mmo_control, seg, subset_id_0, ops->group_id0);
+	DEVX_SET(regexp_mmo_control, seg, subset_id_1, ops->group_id1);
+	DEVX_SET(regexp_mmo_control, seg, subset_id_2, ops->group_id2);
+	DEVX_SET(regexp_mmo_control, seg, subset_id_3, ops->group_id3);
+}
+
+static __rte_always_inline void
+mlx5dv_set_metadata_seg(struct mlx5_wqe_metadata_seg *seg,
+			uint32_t mmo_control_31_0, uint32_t lkey,
+			uintptr_t address)
+{
+	seg->mmo_control_31_0 = htobe32(mmo_control_31_0);
+	seg->lkey = htobe32(lkey);
+	seg->addr = htobe64(address);
+}
+
+int mlx5_regex_enqueue(struct rte_regex_dev *dev, uint16_t q_id,
+		       struct rte_regex_ops **ops, uint16_t nb_ops);
+
+#endif /* MLX5_REGEX_QUEUE_H_ */


### PR DESCRIPTION
Implement enqueue function.
Need to finalize on mlx5_regex_queue structure, fields and resources.