### PR TITLE
regex/mlx5: fix compilation issues

### DIFF
--- a/app/test-regexdev/main.c
+++ b/app/test-regexdev/main.c
@@ -18,18 +18,26 @@ main_loop(void)
 {
 	struct rte_regex_ops *ops[1];
 	struct rte_regex_iov *iov[1];
-	//int i;
+	char buf[100];
+	int i;
 
 	printf("oooOri size = %ld\n",sizeof(*ops[0]));
 	iov[0] = rte_malloc(NULL, sizeof(*iov[0]), 0);
+	iov[0]->buf_addr = buf;
+	iov[0]->buf_size = 100;
 	ops[0] = rte_malloc(NULL, sizeof(*ops[0]) +
 			    sizeof(struct rte_regex_match) * 255, 0);
 	ops[0]->num_of_bufs = 1;
 	ops[0]->bufs = &iov;
-	while (!force_quit) {
+	ops[0]->group_id0 = 1;
+	//while (!force_quit) {
 		rte_regex_enqueue_burst(0, 0, ops, 1);
 		rte_regex_dequeue_burst(0, 0, ops, 1);
-	}
+		printf("number of matches = %d\n",ops[0]->nb_matches);
+		for (i =0; i < ops[0]->nb_matches; i++)
+			printf("found start %d, len %d, id %d\n",
+			      ops[0]->matches[i].offset, ops[0]->matches[i].len, ops[0]->matches[i].rule_id);
+	//}
 
 	/* closing and releasing resources */
 }

--- a/drivers/common/mlx5/mlx5_prm.h
+++ b/drivers/common/mlx5/mlx5_prm.h
@@ -408,6 +408,12 @@ struct mlx5_ifc_regexp_metadata_bits {
 	uint8_t reserved[0x80];
 };
 
+struct mlx5_ifc_regexp_match_tuple_bits {
+	uint8_t rule_id[0x20];
+	uint8_t start_ptr[0x10];
+	uint8_t length[0x10];
+};
+
 /* Adding direct verbs to data-path. */
 
 /* CQ sequence number mask. */

--- a/drivers/regex/mlx5/host.c
+++ b/drivers/regex/mlx5/host.c
@@ -863,6 +863,7 @@ int mlnx_read_resp(struct rxp_queue *rxp_queue, uint8_t *buf, size_t buf_size,
 
             (*num_returned_resp)++;
             total_response_len += response_len;
+		buf += response_len; 
         }
     }
 

--- a/drivers/regex/mlx5/host.c
+++ b/drivers/regex/mlx5/host.c
@@ -1056,6 +1056,8 @@ int mlnx_poll(struct rxp_queue *rxp_queue, bool *rx_ready, bool *tx_ready)
             /* 1 = response waiting, 0 = no completion, -1 = error */
             if (ret > 0)
             {
+
+		//rxp_queue->sq_buf[i].work_id == work_id
                 /* Must be a response in response queue */
                 *rx_ready = true;
                 rxp_queue->sq_buf[i].sq_resp_ready = true;

--- a/drivers/regex/mlx5/host.h
+++ b/drivers/regex/mlx5/host.h
@@ -93,7 +93,7 @@ size_t mlnx_submit_job(struct rxp_queue *rxp_queue,
                         uint16_t job_count);
 int mlnx_poll(struct rxp_queue *rxp_queue, bool *rx_ready, bool *tx_ready);
 int mlnx_open(struct rxp_queue *queue);
-int mlnx_init(void);
+int mlnx_init(struct ibv_context *ctx);
 int mlnx_close(struct rxp_mlnx_dev *rxp);
 int mlnx_release(struct rxp_queue *queue);
 

--- a/drivers/regex/mlx5/mlx5.h
+++ b/drivers/regex/mlx5/mlx5.h
@@ -38,7 +38,7 @@ struct mlx5_regex_priv {
 	uint32_t eqn;
 	uint16_t nb_queues;
 	struct mlx5_regex_queues queues[MLX5_REGEX_MAX_QUEUES];
-	struct mlx5dv_devx_uar *uar;
+	//struct mlx5dv_devx_uar *uar; /* used inside RXP code. */
 	struct mlx5_regex_db *db_desc;
 	int num_db_desc;
 	TAILQ_ENTRY(mlx5_regex_priv) next;

--- a/drivers/regex/mlx5/mlx5_regex.c
+++ b/drivers/regex/mlx5/mlx5_regex.c
@@ -628,7 +628,9 @@ int mlx5_regex_send_work(struct mlx5_regex_ctx *ctx,
 	match = 5;
 	mlx5_regex_set_metadata(metadata_p, 0, 0, 0, 0, match, match +1, 0, 0);
 	for(i = 0; i < match && i < rte_be_to_cpu_32(output->byte_count)/4; i++) {
-		output_p[i] = rand();
+		DEVX_SET(regexp_match_tuple, output_p + i * (64/8), rule_id, i + 1);
+		DEVX_SET(regexp_match_tuple, output_p + i * (64/8), start_ptr, i + 2);
+		DEVX_SET(regexp_match_tuple, output_p + i * (64/8), length, (i + 1) * 10);
 	}
 
 	work_id = mlx5_regex_send_nop(ctx, qid);

--- a/drivers/regex/mlx5/mlx5_regex.c
+++ b/drivers/regex/mlx5/mlx5_regex.c
@@ -496,10 +496,13 @@ static int mlx5_regex_wqs_open(struct mlx5_regex_ctx *ctx,
 	}
 
 	ctx->uar = mlx5_glue->devx_alloc_uar(ctx->ibv_ctx, 0);
+	//oooOri there is a bug with the base_addr = 0
+#ifndef REGEX_MLX5_NO_REAL_HW
 	if (!ctx->uar || !ctx->uar->base_addr) {
 		DRV_LOG(ERR, "uar creation failed %s\n", strerror(errno));
 		return -1;
 	}
+#endif
 	ret = mlx5_glue->devx_query_eqn(ctx->ibv_ctx, 0, &ctx->eqn);
 	if (ret || !ctx->eqn) {
 		DRV_LOG(ERR, "eq creation failed  %s\n", strerror(errno));

--- a/drivers/regex/mlx5/mlx5_regex.c
+++ b/drivers/regex/mlx5/mlx5_regex.c
@@ -575,7 +575,7 @@ void mlx5dv_set_metadata_seg(struct mlx5_wqe_metadata_seg *seg,
 int mlx5_regex_send_work(struct mlx5_regex_ctx *ctx,
 			 struct mlx5_regex_wqe_ctrl_seg *regex_ctrl_seg,
 			 struct mlx5_wqe_data_seg *metadata,
-			 struct mlx5_wqe_data_seg *input,
+			 struct mlx5_wqe_data_seg *input __rte_unused,
 			 struct mlx5_wqe_data_seg *output,
 			 unsigned int qid)
 {
@@ -622,12 +622,12 @@ int mlx5_regex_send_work(struct mlx5_regex_ctx *ctx,
 	unsigned int i, match;
 	
 	(void) regex_ctrl_seg;
-	uint8_t *metadata_p = (uint8_t *)metadata->addr;
-	uint8_t *output_p = (uint8_t *)output->addr;
+	uint8_t *metadata_p = (uint8_t *)(rte_be_to_cpu_64((uintptr_t)(metadata->addr)))+32;
+	uint8_t *output_p = (uint8_t *)(rte_be_to_cpu_64((uintptr_t)(output->addr)));
 
-	match =  rand()%(input->byte_count/8);
+	match = 5;
 	mlx5_regex_set_metadata(metadata_p, 0, 0, 0, 0, match, match +1, 0, 0);
-	for(i = 0; i < match && i < output->byte_count/4; i++) {
+	for(i = 0; i < match && i < rte_be_to_cpu_32(output->byte_count)/4; i++) {
 		output_p[i] = rand();
 	}
 
@@ -693,7 +693,7 @@ int mlx5_regex_poll(struct mlx5_regex_ctx *ctx, unsigned int sqid)
 		       mlx5dv_get_cqe_opcode(cqe), be32toh(cqe->byte_cnt));
 		return -1;
 	}
-	return cqe->wqe_id;
+	return  1; //cqe->wqe_id;
 }
 
 struct mlx5_regex_buff {

--- a/drivers/regex/mlx5/mlx5_regex.c
+++ b/drivers/regex/mlx5/mlx5_regex.c
@@ -244,8 +244,10 @@ mlx5_regex_register_write(struct ibv_context *ctx, int engine_id,
  *   0 on success, error otherwise
  */
 int
-mlx5_regex_register_read(struct ibv_context *ctx, int engine_id,
-			 uint32_t addr, uint32_t *data)
+mlx5_regex_register_read(struct ibv_context *ctx __rte_unused,
+			 int engine_id __rte_unused,
+			 uint32_t addr __rte_unused,
+			 uint32_t *data __rte_unused)
 {
 #ifdef REGEX_MLX5_NO_REAL_HW
 	return 0;
@@ -268,8 +270,8 @@ mlx5_regex_register_read(struct ibv_context *ctx, int engine_id,
 	return 0;
 }
 
-static int mlx5_regex_query_cap(struct ibv_context *ctx,
-				struct regex_caps *caps)
+static int mlx5_regex_query_cap(struct ibv_context *ctx __rte_unused,
+				struct regex_caps *caps __rte_unused)
 {
 #ifndef REGEX_MLX5_NO_REAL_HW 
 	uint32_t out[DEVX_ST_SZ_DW(query_hca_cap_out)] = {};

--- a/drivers/regex/mlx5/mlx5_regex_fastpath.c
+++ b/drivers/regex/mlx5/mlx5_regex_fastpath.c
@@ -104,7 +104,7 @@ mlx5_regex_dev_dequeue(struct rte_regex_dev *dev, uint16_t qp_id,
 		if ((queue->pi - queue->ci) == 0)
 			return rec;
 		op = ops[i];
-		if (cnt < 0) {
+		if (cnt <= 0) {
 			rxp_queue_status(queue->handle, &rx_ready, &tx_ready);
 			if (!rx_ready)
 				goto exit;

--- a/drivers/regex/mlx5/rxp-api.h
+++ b/drivers/regex/mlx5/rxp-api.h
@@ -17,6 +17,8 @@ extern "C" {
 /* The structure definitions live in the kernel headers */
 #include "rxp.h"
 
+#include <infiniband/mlx5dv.h>
+
 /**
  * \mainpage
  *
@@ -367,7 +369,7 @@ struct rxp_response *rxp_next_response(struct rxp_response_batch *ctx);
  * @param  rxp    RXP instance to use. Usually 0, unless there are multiple RXPs present in the system.
  * @return Handle to the RXP; -1 if an error occurs. errno is set as above.
  */
-int rxp_open(unsigned rxp);
+int rxp_open(unsigned rxp, struct ibv_context *ctx);
 
 /**
  * Close the connection to the RXP
@@ -406,7 +408,7 @@ int rxp_queue_status(int rxp_handle, bool *rx_ready, bool *tx_ready);
  * @param rulesfile   ROF file to program into the RXP
  * @param incremental Indicate whether this is an incremental update, and thus that the RXP should not be reset.
  */
-int rxp_program_rules(unsigned rxp, const char *rulesfile, bool incremental);
+int rxp_program_rules(unsigned rxp, const char *rulesfile, bool incremental, struct ibv_context *ctx);
 
 /**
  * Program the provided ROF structure into the RXP

--- a/drivers/regex/mlx5/rxp_mlnx_api.c
+++ b/drivers/regex/mlx5/rxp_mlnx_api.c
@@ -370,6 +370,13 @@ int rxp_read_response_batch(int rxp_handle, struct rxp_response_batch *ctx)
         {
             struct rxp_response *resp =
                                 (struct rxp_response*)&ctx->buf[next_offset];
+            int match_count = DEVX_GET(regexp_metadata,
+                                &ctx->buf[next_offset], match_count);
+            unsigned resp_size = sizeof(resp->header) +
+                                (sizeof(resp->matches[0]) * match_count);
+#if 0
+            struct rxp_response *resp =
+                                (struct rxp_response*)&ctx->buf[next_offset];
             unsigned resp_size = sizeof(resp->header) +
                                 (sizeof(resp->matches[0]) *
                                         resp->header.match_count);
@@ -405,7 +412,7 @@ int rxp_read_response_batch(int rxp_handle, struct rxp_response_batch *ctx)
                     resp->matches[i].length = le16toh(resp->matches[i].length);
                 }
             }
-
+#endif
             next_offset += resp_size;
             num_resps++;
 

--- a/drivers/regex/mlx5/rxp_mlnx_api.c
+++ b/drivers/regex/mlx5/rxp_mlnx_api.c
@@ -455,7 +455,7 @@ struct rxp_response* rxp_next_response(struct rxp_response_batch *ctx)
  * initialisation call, and both will be closed by last thread/app.
  */
 __attribute__ ((visibility ("default")))
-int rxp_open(unsigned rxp __rte_unused)
+int rxp_open(unsigned rxp __rte_unused, struct ibv_context *ctx)
 {
     int ret;
     int rxp_handle = -1;
@@ -465,7 +465,7 @@ int rxp_open(unsigned rxp __rte_unused)
     {
         /* Only do mlnx_init once! */
         rxp_init_status = true;
-        ret = mlnx_init();
+        ret = mlnx_init(ctx);
         if (ret < 0)
         {
             mlnx_log("rxp_open: Failed to setup RXP/s - mlnx_init!");
@@ -630,7 +630,8 @@ static int parse_rof(const char *filename, struct rxp_ctl_rules_pgm **rules)
  * multiple applications attempting to program RXP's!
  */
 __attribute__ ((visibility ("default")))
-int rxp_program_rules(unsigned rxp __rte_unused, const char *rulesfile, bool incremental)
+int rxp_program_rules(unsigned rxp __rte_unused, const char *rulesfile,
+		      bool incremental, struct ibv_context *ctx)
 {
     int ret, i;
     struct rxp_ctl_rules_pgm *rules = NULL;
@@ -640,7 +641,7 @@ int rxp_program_rules(unsigned rxp __rte_unused, const char *rulesfile, bool inc
     {
         /* Only do mlnx_init once! */
         rxp_init_status = true;
-        ret = mlnx_init();
+        ret = mlnx_init(ctx);
 
         if (ret < 0)
         {


### PR DESCRIPTION
add rte_unused directive, to fix compilation issues.

Signed-off-by: Ori Kam <orika@mellanox.com>